### PR TITLE
Clear /contributors directory

### DIFF
--- a/buildpage.js
+++ b/buildpage.js
@@ -3,6 +3,8 @@ var fs = require('fs')
 var request = require('request')
 var btoa = require('btoa')
 
+var clearUser = require('./clearuser.js')
+
 module.exports = function (callback) {
   if (process.env['CONTRIBUTORS']) {
     fs.readFile(process.env['CONTRIBUTORS'], function (err, data) {

--- a/buildpage.js
+++ b/buildpage.js
@@ -23,7 +23,8 @@ module.exports = function (callback) {
   function organizeData (data) {
     var everyone = JSON.parse(data)
     // TODO Fix counting this
-    var everyoneCount = everyone.length + 12425 // From archive
+    var archiveCount = 12425
+    var everyoneCount = everyone.length + archiveCount
     var everyoneCommas = everyoneCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
     var newest = everyone[everyone.length - 1]
     var topHundred = everyone.reverse().slice(0, 100)

--- a/buildpage.js
+++ b/buildpage.js
@@ -72,7 +72,7 @@ module.exports = function (callback) {
       request.put(options, function (err, res, body) {
         if (err) return callback(err, 'Error writing new index to Patchwork')
         console.log(new Date(), 'Rebuilt index with ' + username)
-        clearUser(callback)
+        clearUser(username, callback)
       })
     })
   }

--- a/buildpage.js
+++ b/buildpage.js
@@ -69,7 +69,8 @@ module.exports = function (callback) {
       options.body.sha = body.sha
       request.put(options, function (err, res, body) {
         if (err) return callback(err, 'Error writing new index to Patchwork')
-        callback(null, 'Rebuilt index with ' + username)
+        console.log(new Date(), 'Rebuilt index with ' + username)
+        clearUser(callback)
       })
     })
   }

--- a/buildpage.js
+++ b/buildpage.js
@@ -22,7 +22,6 @@ module.exports = function (callback) {
 
   function organizeData (data) {
     var everyone = JSON.parse(data)
-    // TODO Fix counting this
     var archiveCount = 12425
     var everyoneCount = everyone.length + archiveCount
     var everyoneCommas = everyoneCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')

--- a/clearuser.js
+++ b/clearuser.js
@@ -1,0 +1,48 @@
+// After Reporobot does everything with a sucessful user, it deltes the file
+// they added because turns out lots of people are doing this and the repo
+// gets bulky quickly
+
+var request = require('request')
+
+var baseURL = 'https://api.github.com/repos/jlord/patchwork/contents/contributors'
+var headers = {
+  'User-Agent': 'request',
+  'Authorization': 'token ' + process.env['REPOROBOT_TOKEN']
+}
+
+module.exports = function deleteFile (callback) {
+  // We could take in username here and delete the specific just-merged-file,
+  // but we might be ok just deleting the last file.
+  var options = {
+    url: baseURL,
+    json: true,
+    headers: headers
+  }
+  // First get info on the file
+  request(options, function (err, response, body) {
+    if (err) return callback(err, 'Did not get file info')
+    deleteFile(body[0])
+  })
+
+  function deleteFile (file) {
+    var options = {
+      url: baseURL + '/' + file.name,
+      json: true,
+      headers: headers,
+      body: {
+        'message': 'Clearing directory',
+        'committer': {
+          'name': 'reporobot',
+          'email': '60ebe73fdad8ee59d45c@cloudmailin.net'
+        },
+        'sha': file.sha,
+        'path': file.path
+      }
+    }
+    request.del(options, function (err, response, body) {
+      if (err) return callback(err, 'Did not delete file')
+      console.log(new Date(), 'Deleted' + file.name)
+      callback(null)
+    })
+  }
+}

--- a/clearuser.js
+++ b/clearuser.js
@@ -41,7 +41,7 @@ module.exports = function deleteFile (callback) {
     }
     request.del(options, function (err, response, body) {
       if (err) return callback(err, 'Did not delete file')
-      console.log(new Date(), 'Deleted' + file.name)
+      console.log(new Date(), 'Deleted ' + file.name)
       callback(null)
     })
   }

--- a/clearuser.js
+++ b/clearuser.js
@@ -49,7 +49,7 @@ module.exports = function deleteFile (username, callback) {
     }
     request.del(options, function (err, response, body) {
       if (err) return callback(err, 'Error with delete request')
-      if (response.statusCode != 200) return callback(new Error(), 'Did not delete file: ' + response.statusCode)
+      if (response.statusCode != 200) return callback(new Error('Non 200 for delete: ' + response.statusCode))
       console.log(new Date(), 'Deleted ' + file.name)
       callback(null)
     })

--- a/clearuser.js
+++ b/clearuser.js
@@ -19,15 +19,20 @@ module.exports = function deleteFile (username, callback) {
   // First get info on the file
   request(options, function (err, response, body) {
     if (err) return callback(err, 'Did not get file info')
-    console.log('Files in contributors: ' + body.length)
-    body.forEach(function (file) {
-      // leave add-jlord.txt there as a sample file
-      if (file.path.match('add-jlord.txt')) return
-      else deleteFile(file)
-    })
+    console.log(new Date(), 'Files in contributors: ' + body.length)
+    loop()
+    function loop () {
+      if (!body.length) return callback(null)
+      var file = body.shift()
+      if (file.path.match('add-jlord.txt')) return loop()
+      deleteFile(file, function (err) {
+        if (err) return callback(err, 'Error deleting file')
+        loop()
+      })
+    }
   })
 
-  function deleteFile (file) {
+  function deleteFile (file, callback) {
     var options = {
       url: baseURL + '/' + file.name,
       json: true,

--- a/clearuser.js
+++ b/clearuser.js
@@ -1,6 +1,6 @@
 // After Reporobot does everything with a sucessful user, it deltes the file
 // they added because turns out lots of people are doing this and the repo
-// gets bulky quickly
+// gets bulky quickly. This file is called from buildpage.js
 
 var request = require('request')
 
@@ -10,9 +10,7 @@ var headers = {
   'Authorization': 'token ' + process.env['REPOROBOT_TOKEN']
 }
 
-module.exports = function deleteFile (callback) {
-  // We could take in username here and delete the specific just-merged-file,
-  // but we might be ok just deleting the last file.
+module.exports = function deleteFile (username, callback) {
   var options = {
     url: baseURL,
     json: true,
@@ -21,7 +19,12 @@ module.exports = function deleteFile (callback) {
   // First get info on the file
   request(options, function (err, response, body) {
     if (err) return callback(err, 'Did not get file info')
-    deleteFile(body[0])
+    console.log('Files in contributors: ' + body.length)
+    body.forEach(function (file) {
+      // leave add-jlord.txt there as a sample file
+      if (file.path.match('add-jlord.txt')) return
+      else deleteFile(file)
+    })
   })
 
   function deleteFile (file) {
@@ -40,7 +43,8 @@ module.exports = function deleteFile (callback) {
       }
     }
     request.del(options, function (err, response, body) {
-      if (err) return callback(err, 'Did not delete file')
+      if (err) return callback(err, 'Error with delete request')
+      if (response.statusCode != 200) return callback(new Error(), 'Did not delete file: ' + response.statusCode)
       console.log(new Date(), 'Deleted ' + file.name)
       callback(null)
     })


### PR DESCRIPTION
This branch is currently in production 💁

The `/contributors` directory gets big, fast (so many people are completing this 🎉 ) so @reporobot needs to be clearing it out so that people don't have to clone a massive repository. 

Originally I had it delete the last file each time the page was rebuilt but it seems too many were coming in so they were still piling up quicker than they were being deleted. So, now:

- [x] See if we can loop through and delete each file without GitHub freaking out and needing more time between actions on a repository. 

Fixes #29 