### PR TITLE
Fix typo: runing => running

### DIFF
--- a/template.hbs
+++ b/template.hbs
@@ -44,7 +44,7 @@
             <li>Create a repository and open an issue to make a <a href="https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments" target="_blank">to-do list</a>.</li>
             <li>Find interesting open source projects to work with in <a href="https://www.github.com/explore" target="_blank">Explore</a>.</li>
             <li>Checkout the GitHub <a href="https://guides.github.com/activities/hello-world">Hello World Guide</a> for more GitHub basics.</li>
-            <li>Fork an existing site to get your own up and runing: <a href="http://jlord.us/forkngo" target="_blank">Fork-n-go</a>.</li>
+            <li>Fork an existing site to get your own up and running: <a href="http://jlord.us/forkngo" target="_blank">Fork-n-go</a>.</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
@jlord Edited the template.hbs file to fix a minor typo in the "What Next?" section (runing => running).